### PR TITLE
[DEV-1]: Set publish access to public in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
 		"prepare": "husky",
 		"prerelease": "npm run format"
 	},
+	"publishConfig": {
+		"access": "public"
+	},
 	"type": "module",
 	"exports": "./index.js",
 	"files": [


### PR DESCRIPTION
## Description

Set publish access to public in package.json

## Checklist

- [ ] All formatting rules have been tested locally with `prettier --check "<your-files-glob>"`.