### PR TITLE
DEV-7 Use Node 24 in release workflow for npm OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          # Node 24 ships with npm 11.x, which is required for npm Trusted
+          # Publishing (OIDC token exchange). Node 22 ships with npm 10.x
+          # which doesn't support it. Both versions satisfy our engines.node
+          # constraint (>=22.22.1), so this is purely a CI-environment choice.
+          node-version: '24.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org/'
-
-      # Node 22 ships with npm 10.x, but Trusted Publishing (OIDC) requires
-      # npm 11.5.1+. Upgrade explicitly so `npm publish` knows how to exchange
-      # the GitHub Actions OIDC token for an npm publish credential.
-      - run: npm install -g npm@latest
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

- Previous attempt (PR #13) added `npm install -g npm@latest` to upgrade npm 10 → 11 in CI, but the upgrade itself crashed mid-flight with `MODULE_NOT_FOUND: 'promise-retry'` — a known issue where old npm corrupts itself while installing its newer self.
- Simpler fix: switch the release workflow to **Node 24**, which ships with npm 11.x out of the box. Node 24 is the current LTS (April 2026) and our `engines.node: >=22.22.1` constraint already allows it. The CI test workflow already runs on a Node 22.x + 24.x matrix, so this is a CI-environment-only change.

## Changes

- Bumped `node-version` in `.github/workflows/release.yml` from `'22.x'` to `'24.x'`.
- Removed the now-unnecessary `npm install -g npm@latest` step.
- Replaced the explanatory comment with one pointing at the npm 11 / OIDC requirement.

## How to merge

CI-only change, no changeset. The `Check Changeset` job will fail — merge with **"Merge without waiting for requirements to be met (bypass rules)"**.

After merge `release.yml` will trigger one more time. With npm 11.x available, the OIDC handshake should finally succeed and publish `@kiforks/prettier-config@2.0.0` to npm.