### PR TITLE
DEV-8 Add verify safety gate and pre push format hook

### DIFF
--- a/.changeset/add-prepublish-and-hook.md
+++ b/.changeset/add-prepublish-and-hook.md
@@ -1,0 +1,19 @@
+---
+'@kiforks/prettier-config': patch
+---
+
+**🔒 Security**
+
+- Added a `prepublishOnly` npm script that runs `npm run format && npm test`.
+  Because npm fires `prepublishOnly` automatically before `npm publish`, this
+  guarantees that a broken or unformatted build can never reach the registry,
+  even if all earlier checks somehow slipped past.
+
+**🧹 Internal**
+
+- The `pre-push` husky hook now also runs `npm run format` after validating
+  the branch name. Pre-commit lint-staged only covers staged files, so this
+  catches stray unformatted files that were committed without staging or via
+  `--no-verify`. Combined with the existing CI job and the new
+  `prepublishOnly`, the project has three independent layers of formatting
+  validation.

--- a/.changeset/add-prepublish-and-hook.md
+++ b/.changeset/add-prepublish-and-hook.md
@@ -4,16 +4,21 @@
 
 **🔒 Security**
 
-- Added a `prepublishOnly` npm script that runs `npm run format && npm test`.
-  Because npm fires `prepublishOnly` automatically before `npm publish`, this
-  guarantees that a broken or unformatted build can never reach the registry,
-  even if all earlier checks somehow slipped past.
+- Added a `verify` npm script (`npm run format && npm test`) and called it
+  explicitly from `.github/workflows/release.yml` right before the release
+  step. If formatting or tests regressed on main between PR merge and the
+  release run, the publish step never starts — the registry can't see a
+  broken build.
 
 **🧹 Internal**
 
 - The `pre-push` husky hook now also runs `npm run format` after validating
   the branch name. Pre-commit lint-staged only covers staged files, so this
   catches stray unformatted files that were committed without staging or via
-  `--no-verify`. Combined with the existing CI job and the new
-  `prepublishOnly`, the project has three independent layers of formatting
+  `--no-verify`. Combined with the existing CI job and the new release-time
+  verify step, the project has three independent layers of formatting
   validation.
+- Resynced `package-lock.json` version field from `1.0.4` to `2.0.0` — the
+  v2 publish bumped `package.json` but `changesets/action` doesn't run
+  `npm install` after `changeset version`, so the lockfile was stuck on the
+  old version.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
 
       - run: npm ci
 
+      # Final safety gate: re-run our own Prettier config against the repo
+      # and execute the full test suite before allowing any release action.
+      # If formatting or tests regressed on main between PR merge and now,
+      # the publish step never even starts.
+      - name: Verify
+        run: npm run verify
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,6 +19,16 @@ if ! echo "$branch_name" | grep -Eq "$branch_regex"; then
   exit 1
 fi
 
-# If all checks pass, allow the push
 echo "✅ Branch name is valid: ${branch_name}."
+
+# Verify the entire repo passes our own Prettier config.
+# Catches files that bypassed lint-staged (e.g. when committing with --no-verify
+# or modifying without staging).
+echo "🔍 Checking formatting with @kiforks/prettier-config..."
+if ! npm run format --silent; then
+  echo "❌ Formatting issues found. Run 'npm run format:fix' to auto-fix, then push again."
+  exit 1
+fi
+echo "✅ All files match our Prettier config."
+
 exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@kiforks/prettier-config",
-	"version": "1.0.4",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@kiforks/prettier-config",
-			"version": "1.0.4",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@ianvs/prettier-plugin-sort-imports": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"format:fix": "prettier '**/*.{ts,html,js,json,yml}' --write",
 		"test": "node --test --test-reporter=spec",
 		"test:update-snapshots": "node tests/update-snapshots.js",
-		"prepare": "husky"
+		"prepare": "husky",
+		"prepublishOnly": "npm run format && npm test"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"format:fix": "prettier '**/*.{ts,html,js,json,yml}' --write",
 		"test": "node --test --test-reporter=spec",
 		"test:update-snapshots": "node tests/update-snapshots.js",
-		"prepare": "husky",
-		"prepublishOnly": "npm run format && npm test"
+		"verify": "npm run format && npm test",
+		"prepare": "husky"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Summary

- End-to-end test of the v2 release pipeline: ship a tiny but real patch change, watch the bot open a Version PR, merge it, and confirm `@kiforks/prettier-config@2.0.1` lands on npm with provenance.
- Adds two new layers of formatting + test protection on top of the existing CI gate, so a broken or unformatted build cannot reach npm even if every earlier check is bypassed.
- Also resyncs `package-lock.json` to `2.0.0` — the v2 publish bumped `package.json` but the changesets bot didn't run `npm install`, so the lockfile was stuck at `1.0.4`.

## Changes

- **Added a `verify` npm script** (`npm run format && npm test`) and called it explicitly from `release.yml` right before the release step. Picked an explicit-CI-step pattern over the npm lifecycle hooks (`prepublishOnly` / `prepublish`) because it's the modern approach in 2026 (used by Vite, Astro, etc.), avoids the install-time side effects of the deprecated `prepublish` hook, and reads cleanly in workflow logs.
- **Extended `.husky/pre-push`** to run `npm run format` after the branch-name validation. Pre-commit `lint-staged` only sees staged files, so this catches stray unformatted files that slipped through (e.g. committed via `--no-verify` or modified but not staged). Pre-push fired correctly while pushing this branch.
- **Synced `package-lock.json` version** field from `1.0.4` to `2.0.0` so the lockfile matches the published artefact again.
- Added a `patch` changeset describing the new safety nets in the next release notes.

## Why this is a good end-to-end test

After this merges, the full release pipeline runs unsupervised:

1. CI on this PR proves the new pre-push and ci-format gates pass.
2. Merging this PR triggers `release.yml` (with the Node 24 + OIDC setup landed in v2.0.0).
3. The bot creates a "Version Packages" PR opened by the PAT user `@kiforks`, which (unlike `GITHUB_TOKEN`-opened PRs) triggers CI workflows.
4. Merging the Version PR fires `release.yml` once more — the new `npm run verify` step runs format + test as the final gate before `npm publish`, and `@kiforks/prettier-config@2.0.1` ships with provenance.