### PR TITLE
DEV-9 Skip changeset status check on the bot version PR

### DIFF
--- a/.changeset/exempt-version-pr.md
+++ b/.changeset/exempt-version-pr.md
@@ -1,0 +1,12 @@
+---
+---
+
+**🐛 Fixes**
+
+- The `changeset-status` CI job now skips the bot-opened Version PR
+  (`changeset-release/main`). That PR is created by `changesets/action`
+  specifically to consume pending changesets instead of adding new ones, so
+  the existing check would fail on every Version PR by design (as it just
+  did on PR #16). With this exact-branch-match skip, Version PRs pass all
+  required CI checks without manual bypass, while every other PR still has
+  to carry a changeset.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
   changeset-status:
     name: 'Check Changeset'
     runs-on: ubuntu-latest
+    # Skip on the bot-opened Version PR (`changeset-release/main`). That PR
+    # consumes changesets instead of adding them, so this check would fail
+    # by design. Exact branch match — `changesets/action` hard-codes the name
+    # as `changeset-release/<base>`, so a regular contributor can't bypass
+    # the check by naming their branch similarly.
+    if: ${{ github.head_ref != 'changeset-release/main' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- The first auto-created Version PR (#16) failed the `Check Changeset` job because the job runs `npx changeset status --since=origin/main`, which requires a new changeset on every PR. Version PRs are created by `changesets/action` specifically to **consume** pending changesets — they cannot add new ones by design, so the check would fail on every bot release.
- Skip the check for the exact bot branch `changeset-release/main`. Every other PR still has to carry a changeset, so the contributor guardrail is intact.
- Side note: PR #16 also proved that all the other parts of the v2 release pipeline now work end-to-end — `Code Quality (22.x)` and `Code Quality (24.x)` ran successfully on the bot PR (PAT trigger works), labels were applied, and the PR title matches the `chore [REL-0]: Release packages` convention.

## Changes

- Added `if: ${{ github.head_ref != 'changeset-release/main' }}` to the `changeset-status` job in `.github/workflows/ci.yml`. Exact-branch-match (not `startsWith`) so a contributor naming their branch `changeset-release/anything` can't bypass the check.
- Added an empty changeset documenting the CI fix in the next release notes.

## What happens after merge

Merging this PR will trigger `release.yml` on `main`. Because the previous Version PR (#16) is still open, `changesets/action` will **update** it in place with the combined content from both pending changesets (the `verify`/pre-push patch from PR #15 + this empty CI fix). The next time PR #16 re-runs its checks, all four required jobs will pass — including the now-exempted `Check Changeset` — so it can be merged without any bypass.