### PR TITLE
DEV-10 Use PAT for checkout so version PR pushes trigger CI

### DIFF
--- a/.changeset/use-pat-for-checkout.md
+++ b/.changeset/use-pat-for-checkout.md
@@ -1,0 +1,12 @@
+---
+---
+
+**🐛 Fixes**
+
+- Pass `CHANGESETS_TOKEN` to `actions/checkout` in `.github/workflows/release.yml`,
+  so the git push that updates the Version PR (`changeset-release/main`) is
+  also authenticated as the PAT user rather than `github-actions[bot]`.
+  Without this, the initial PR creation triggered CI correctly (because the
+  GitHub API call used the PAT), but subsequent force-push updates skipped
+  workflow runs — leaving the Version PR's required checks stuck in
+  "Expected — Waiting for status to be reported".

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use the PAT for git operations too, not just GitHub API. Without
+          # this, `actions/checkout` configures git remote with the default
+          # GITHUB_TOKEN, so when `changesets/action` later runs
+          # `git push --force origin changeset-release/main` to update the
+          # Version PR, the push is authored by github-actions[bot] — and
+          # GitHub deliberately skips workflow triggers for events caused by
+          # GITHUB_TOKEN, leaving the Version PR's required checks stuck in
+          # "Expected" forever.
+          token: ${{ secrets.CHANGESETS_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- PR #16 (the open Version PR) is stuck: its required CI checks are reported as "Expected — Waiting for status to be reported", because the latest force-push by `changesets/action` was authored by `github-actions[bot]` and GitHub deliberately suppresses workflow triggers for events caused by `GITHUB_TOKEN`.
- The initial PR creation worked because that step uses the GitHub API, where we already pass `CHANGESETS_TOKEN` (a PAT) via the `GITHUB_TOKEN` env var. Subsequent updates of the same PR happen via raw `git push`, which uses the credentials stored by `actions/checkout` — and there we never passed the PAT.
- Adding `token: ${{ secrets.CHANGESETS_TOKEN }}` to `actions/checkout` makes git operations also authenticated as the PAT user, so force-pushes to `changeset-release/main` re-trigger CI on PR #16 like any normal push.

## Changes

- `.github/workflows/release.yml`: pass `CHANGESETS_TOKEN` to `actions/checkout`, with an inline comment explaining why GITHUB_TOKEN is insufficient here.
- Empty changeset documenting the CI fix in the next release notes.

## What happens after merge

1. Merging this PR pushes a new commit to `main`, triggering `release.yml` with the fixed workflow.
2. `changesets/action` runs again, sees the pending changesets, and force-pushes the updated content to `changeset-release/main` — now using the PAT.
3. PR #16 gets its CI checks finally triggered: `Code Quality (22.x)`, `Code Quality (24.x)`, `labeler` all run; `Check Changeset` is skipped by the rule landed in PR #17.
4. PR #16 turns fully green and can be merged without `bypass rules`.
5. Merging PR #16 triggers `release.yml` one more time, which runs `npm run verify` and publishes `@kiforks/prettier-config@2.0.1` to npm with provenance.